### PR TITLE
fix: search_content pagination always fetches the same page

### DIFF
--- a/src/mcp_server_weibo/weibo.py
+++ b/src/mcp_server_weibo/weibo.py
@@ -179,7 +179,7 @@ class WeiboCrawler:
                 params = {
                     'containerid': f'100103type=1&q={keyword}',
                     'page_type': 'searchall',
-                    'page': page,
+                    'page': current_page,
                 }
                 encoded_params = urlencode(params)
 


### PR DESCRIPTION
## Problem

The `search_content` method in `weibo.py` has a pagination bug. It initializes `current_page` from the `page` parameter and increments it each loop iteration, but the request params dict always uses the original `page` value instead of `current_page`:

```python
current_page = page
while len(results) < limit:
    params = {
        'page': page,        # ← Bug: should be current_page
    }
    ...
    current_page += 1        # ← This increment is never used
```

This causes every pagination request to fetch the same page repeatedly, resulting in **duplicate results** when `limit` exceeds a single page size.

## Fix

One-line change: `'page': page` → `'page': current_page`

## Impact

- **Before**: `search_content(keyword, limit=30)` returns duplicates from page 1
- **After**: Correctly paginates through multiple pages

Found while integrating mcp-server-weibo with [Agent-Reach](https://github.com/Panniantong/Agent-Reach) for the Weibo channel.